### PR TITLE
allow options fr dropdown custom fields tb read

### DIFF
--- a/clickupython/models.py
+++ b/clickupython/models.py
@@ -245,7 +245,25 @@ class Creator(BaseModel):
     profile_picture: str = None
 
 
+class Option(BaseModel):
+
+    id: Optional[str]
+
+    name: Optional[str]
+
+    color: Optional[str]
+
+    order_index: Optional[int]
+
 class TypeConfig(BaseModel):
+
+    default: Optional[int]
+
+    placeholder: Optional[str]
+
+    new_drop_down: Optional[bool]
+
+    options: Optional[List[Option]]
 
     include_guests: Optional[bool]
 


### PR DESCRIPTION
Hi!! I made a contribuition for the library to be able to read the **options** from **custom fields**. Right now it can only read the index value of a dropdown. With the suggested changes we can read the **options** object, where there is the name, color etc information, therefore allowing to read the option name, not only the index.

I added the class `Options` that holds the information for each option for a given custom field.