### PR TITLE
Make thumbnails optional for add attachment

### DIFF
--- a/clickupython/models.py
+++ b/clickupython/models.py
@@ -145,9 +145,9 @@ class Attachment(BaseModel):
 
     extension: str
 
-    thumbnail_small: str
+    thumbnail_small: Optional[str] = ""
 
-    thumbnail_large: str
+    thumbnail_large: Optional[str] = ""
     url: str
 
     def build_attachment(self):


### PR DESCRIPTION
Not all attachments are images. Suggesting that the 2 thumb values are optional as a result. 

Without making the 2 thumbs optional, validation errors are thrown when uploading non-images. It seems like the uploads still succeed, but the upload success message never appears - not sure if other steps are skipped. 

Thanks for considering. 